### PR TITLE
Set container to 3.10 and remove unused nodeJS arg

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,9 +10,7 @@
 			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3.8-bullseye",
-			// Options
-			"NODE_VERSION": "none"
+			"VARIANT": "3.10-bullseye",
 		}
 	},
 


### PR DESCRIPTION
- The node JS argument isn't used by the container.
- The container template defaults to 3.10, but the devcontainer sets 3.8, 3.10 would be preferable.